### PR TITLE
Upgrade typography

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,8 +25,13 @@
     "tests"
   ],
   "dependencies": {
-    "polymer": "~1.7.1",
-    "d2l-colors": "~2.2.3",
-    "d2l-typography": "~5.2.3"
+    "polymer": "^1.7.1",
+    "d2l-button": "^3.0.8",
+    "d2l-colors": "^2.2.3",
+    "d2l-icons": "^3.1.0",
+    "d2l-typography": "^5.3.0"
+  },
+  "devDependencies": {
+    "webcomponentsjs": "^0.7.24"
   }
 }

--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -8,7 +8,7 @@
 	<template>
 		<style include="d2l-typography d2l-typography-shared-styles">
 			:host {
-				@apply(--d2l-body-small-text);
+				@apply --d2l-body-small-text;
 				animation: 600ms ease drop-in;
 				display: flex;
 				flex-direction: row;

--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -124,12 +124,12 @@
 				<div class="message-highlight"></div>
 				<slot></slot>
 			</div>
-			<button is="d2l-button" class="d2l-typography" on-tap="_fireAlertButtonPressedEvent" hidden="[[!hasButton]]">
+			<button is="d2l-button" class="d2l-typography" on-tap="_fireAlertButtonPressedEvent" hidden$="[[!hasButton]]">
 				<div class="inner-button d2l-body-compact">
 					[[buttonMessage]]
 				</div>
 			</button>
-			<button is="d2l-button" title="[[closeButtonTitle]]" on-tap="_fireAlertClosedEvent" hidden="[[!hasCloseButton]]">
+			<button is="d2l-button" title$="[[closeButtonTitle]]" on-tap="_fireAlertClosedEvent" hidden$="[[!hasCloseButton]]">
 				<div class="inner-button">
 					<d2l-icon class="close-icon" icon="d2l-tier1:close-default"></d2l-icon>
 				</div>

--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -6,7 +6,7 @@
 
 <dom-module id="d2l-alert">
 	<template>
-		<style include="d2l-typography d2l-typography-shared-styles">
+		<style>
 			:host {
 				@apply --d2l-body-small-text;
 				animation: 600ms ease drop-in;
@@ -116,6 +116,10 @@
 				justify-content: center;
 				align-items: center;
 			}
+
+			.d2l-alert-button {
+				@apply --d2l-body-compact-text;
+			}
 		}
 		</style>
 
@@ -124,8 +128,8 @@
 				<div class="message-highlight"></div>
 				<slot></slot>
 			</div>
-			<button is="d2l-button" class="d2l-typography" on-tap="_fireAlertButtonPressedEvent" hidden$="[[!hasButton]]">
-				<div class="inner-button d2l-body-compact">
+			<button is="d2l-button" on-tap="_fireAlertButtonPressedEvent" hidden$="[[!hasButton]]">
+				<div class="inner-button d2l-alert-button">
 					[[buttonMessage]]
 				</div>
 			</button>

--- a/demo/d2l-alert-demo.html
+++ b/demo/d2l-alert-demo.html
@@ -27,6 +27,8 @@
 		<main class="max-width">
 			<h1>d2l-alert demo</h1>
 			<script>
+				'use strict';
+				
 				function showAlert(type) {
 					hideAllAlerts();
 					var alert = document.querySelector('d2l-alert[type=' + type + ']');
@@ -35,7 +37,7 @@
 
 				function hideAllAlerts() {
 					var alerts = document.getElementsByTagName('d2l-alert');
-					for (i = 0; i < alerts.length; i++) {
+					for (var i = 0; i < alerts.length; i++) {
 						alerts[i].classList.add('not-visible');
 					}
 				}


### PR DESCRIPTION
@CodeBaboon A few different changes in here:
- Using `^` for Bower dependencies instead of `~` so that we can take minor version bumps without crazy conflicts
- Adding in a few Bower deps that were referenced in the prod and dev code
- Main motivation for the PR: upgrade to typography 5.3, which no longer needs `include` of `d2l-typography` (wasn't ever needed) or `d2l-typography-shared-styles` to use the mixins
- Fixed some linting errors

There are still some unrelated linting errors in the demo file you may want to look at.