### PR TITLE
the mesage highlight was sometimes seen as both first and last child

### DIFF
--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -24,10 +24,10 @@
 			:host-context([dir='rtl']) .alert-wrapper :first-child {
 				border-radius: 0 3px 3px 0;
 			}
-			.alert-wrapper :last-child {
+			.alert-wrapper :last-child:not(.message-highlight) {
 				border-radius: 0 3px 3px 0;
 			}
-			:host-context([dir='rtl']) .alert-wrapper :last-child {
+			:host-context([dir='rtl']) .alert-wrapper :last-child:not(.message-highlight) {
 				border-radius: 3px 0 0 3px;
 			}
 			.message-wrapper {


### PR DESCRIPTION
Causing weirdness:
![image](https://user-images.githubusercontent.com/14077760/28138928-132e07f4-6718-11e7-8ca1-d7a8cdcabd1d.png)
