### PR TITLE
cut down d2l-alert size

### DIFF
--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
-<link rel="import" href="../d2l-icons/d2l-icons.html">
+<link rel="import" href="../d2l-icons/tier1-icons.html">
 <link rel="import" href="../d2l-button/d2l-button.html">
 <link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
 


### PR DESCRIPTION
Components that import d2l-alert save about 200kb by having the alert be more precise about its icon set.